### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/style-and-lint.yaml
+++ b/.github/workflows/style-and-lint.yaml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
 
   style-and-lint:


### PR DESCRIPTION
Potential fix for [https://github.com/davep/dhv/security/code-scanning/1](https://github.com/davep/dhv/security/code-scanning/1)

In general, the fix is to explicitly declare minimal GITHUB_TOKEN permissions in the workflow, either at the root level (applies to all jobs) or per job. Since this workflow has a single job and needs only to read repository contents (for checkout and running checks), we can set `permissions: contents: read`. This restricts the token from performing write operations on the repository while still allowing required read access.

The best minimal fix without changing existing functionality is to add a `permissions` block at the top level of `.github/workflows/style-and-lint.yaml`, beneath the `on:` section (or directly under `name:`), so it applies to the entire workflow. Specifically, update `.github/workflows/style-and-lint.yaml` to include:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are needed because this is a declarative GitHub Actions configuration change only. Functionality of all existing steps remains unchanged; they already only read from the repository.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
